### PR TITLE
Make tests running on CircleCI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /node_modules
 /app/bower_components
-.idea
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /app/bower_components
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+  - "4"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+before_script:
+  - npm install
+script:
+ - node node_modules/karma/bin/karma start test/karma.conf.js  --single-run

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![Circle CI](https://circleci.com/gh/devops-course/kinneret-client.svg?style=svg)](https://circleci.com/gh/devops-course/kinneret-client)
-[![Codacy Badge](https://api.codacy.com/project/badge/grade/bd44de0208974b9a87b58b3c8164032c)](https://www.codacy.com/app/devops-course/kinneret-client)
+[![Circle CI](https://circleci.com/gh/boris-org/kinneret-client.svg?style=svg)](https://circleci.com/gh/boris-org/kinneret-client)
+[![codecov.io](https://codecov.io/gh/boris-org/kinneret-client/coverage.svg?branch=master)](https://codecov.io/github/boris-org/kinneret-client?branch=master)
+[![Codacy Badge](https://api.codacy.com/project/badge/grade/bd44de0208974b9a87b58b3c8164032c)](https://www.codacy.com/app/boris-org/kinneret-client)
 
 ![alt text](https://avatars0.githubusercontent.com/u/139426?v=3&s=400 "AngularJS FTW!")
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Circle CI](https://circleci.com/gh/boris-org/kinneret-client.svg?style=svg)](https://circleci.com/gh/boris-org/kinneret-client)
+[![Travis CI](https://travis-ci.org/boris-org/kinneret-client.svg?branch=master)](https://travis-ci.org/boris-org/kinneret-client)
 [![codecov.io](https://codecov.io/gh/boris-org/kinneret-client/coverage.svg?branch=master)](https://codecov.io/github/boris-org/kinneret-client?branch=master)
 [![Codacy Badge](https://api.codacy.com/project/badge/grade/bd44de0208974b9a87b58b3c8164032c)](https://www.codacy.com/app/boris-org/kinneret-client)
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,5 @@
 test:
   override:
     - node node_modules/karma/bin/karma start test/karma.conf.js  --single-run
+  post:
+    - find . -type f -regex ".*/test_out/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/ \;

--- a/circle.yml
+++ b/circle.yml
@@ -3,3 +3,8 @@ test:
     - node node_modules/karma/bin/karma start test/karma.conf.js  --single-run
   post:
     - find . -type f -regex ".*/test_out/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/ \;
+deployment:
+  codecov:
+    branch: /.*/
+    commands:
+      - bash <(curl -s https://codecov.io/bash)

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - node node_modules/karma/bin/karma start test/karma.conf.js  --single-run

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,3 @@ test:
     - node node_modules/karma/bin/karma start test/karma.conf.js  --single-run
   post:
     - find . -type f -regex ".*/test_out/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/ \;
-deployment:
-  codecov:
-    branch: /.*/
-    commands:
-      - bash <(curl -s https://codecov.io/bash)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "karma-jasmine": "^0.1.5",
     "protractor": "~1.0.0",
     "http-server": "^0.8.0",
-    "bower": "^1.3.1"
+    "bower": "^1.3.1",
+    "phantomjs": "^2.1.7",
+    "karma-phantomjs-launcher": "^1.0.0"
   },
   "scripts": {
     "postinstall": "bower install",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "http-server": "^0.8.0",
     "bower": "^1.3.1",
     "phantomjs": "^2.1.7",
-    "karma-phantomjs-launcher": "^1.0.0",
-    "karma-coverage": "^0.5.5"
+    "karma-phantomjs-launcher": "^1.0.0"
   },
   "scripts": {
     "postinstall": "bower install",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "http-server": "^0.8.0",
     "bower": "^1.3.1",
     "phantomjs": "^2.1.7",
-    "karma-phantomjs-launcher": "^1.0.0"
+    "karma-phantomjs-launcher": "^1.0.0",
+    "karma-coverage": "^0.5.5"
   },
   "scripts": {
     "postinstall": "bower install",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -19,6 +19,10 @@ module.exports = function(config){
 
     browsers : ['PhantomJS'],
 
+    preprocessors: {
+      'src/**/*.js': ['coverage']
+    },
+
     plugins : [
             'karma-chrome-launcher',
             'karma-firefox-launcher',
@@ -29,7 +33,13 @@ module.exports = function(config){
     junitReporter : {
       outputFile: 'test_out/unit.xml',
       suite: 'unit'
+    },
+
+    coverageReporter: {
+      type : 'xml',
+      dir : 'test_out/'
     }
+
 
   });
 };

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -17,12 +17,13 @@ module.exports = function(config){
 
     frameworks: ['jasmine'],
 
-    browsers : ['Chrome'],
+    browsers : ['PhantomJS'],
 
     plugins : [
             'karma-chrome-launcher',
             'karma-firefox-launcher',
-            'karma-jasmine'
+            'karma-jasmine',
+            'karma-phantomjs-launcher'
             ],
 
     junitReporter : {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -27,7 +27,8 @@ module.exports = function(config){
             'karma-chrome-launcher',
             'karma-firefox-launcher',
             'karma-jasmine',
-            'karma-phantomjs-launcher'
+            'karma-phantomjs-launcher',
+            'karma-coverage'
             ],
 
     junitReporter : {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config){
     frameworks: ['jasmine'],
 
     browsers : ['PhantomJS'],
-
+    reporters: ['progress', 'coverage'],
     preprocessors: {
       'src/**/*.js': ['coverage']
     },
@@ -37,7 +37,7 @@ module.exports = function(config){
     },
 
     coverageReporter: {
-      type : 'xml',
+      type : 'html',
       dir : 'test_out/'
     }
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -18,29 +18,18 @@ module.exports = function(config){
     frameworks: ['jasmine'],
 
     browsers : ['PhantomJS'],
-    reporters: ['progress', 'coverage'],
-    preprocessors: {
-      'src/**/*.js': ['coverage']
-    },
 
     plugins : [
             'karma-chrome-launcher',
             'karma-firefox-launcher',
             'karma-jasmine',
-            'karma-phantomjs-launcher',
-            'karma-coverage'
+            'karma-phantomjs-launcher'
             ],
 
     junitReporter : {
       outputFile: 'test_out/unit.xml',
       suite: 'unit'
-    },
-
-    coverageReporter: {
-      type : 'html',
-      dir : 'test_out/'
     }
-
 
   });
 };

--- a/test_out/unit.xml
+++ b/test_out/unit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<testsuite name="PhantomJS 1.9.8 (Linux)" package="models" timestamp="2015-03-10T13:59:23" id="0" hostname="admin" tests="629" errors="0" failures="0" time="11.452">
+  <properties>
+    <property name="browser.fullName" value="Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.8 Safari/534.34"/>
+  </properties>
+ <testcase name="(C.2) Checks if an empty object is returned when error 404 is encountered" time="0.01" classname="PhantomJS_1_9_8_(Linux).models.AnalyticsModule_test"/>
+ <testcase name="(C.3) Checks if an empty array is returned when error 405 is encountered" time="0.013" classname="PhantomJS_1_9_8_(Linux).models.AnalyticsModule_test"/>
+</testsuite>


### PR DESCRIPTION
Guys, I've made the following changes:
1. Added PhantomJS for headless test run. PhantomJS only runs in current configuration because I do not know how to make it conditionally (run phantomjs on circleci and chrome locally? some command line option?)
2. Configured circleci.yml so that this command runs on each build:  `node node_modules/karma/bin/karma start test/karma.conf.js  --single-run`
3. All XML files under test_out directory will be assumed as test results and collected to be displayed in CircleCI screens. Since I do not know how to actually produce this file (just see it is defined in configuration) I manually added test_out/unit.xml file for testing.
See the result of the changes [here](https://circleci.com/gh/boris-org/kinneret-client/4)
Please use it as a base for further changes or let me know if I did something wrong.
Thanks, Boris
